### PR TITLE
fix: display Barrel Golem's held item by using correct bone name

### DIFF
--- a/src/main/java/tech/alexnijjar/golemoverhaul/client/renderers/entities/golems/layers/BarrelGolemHeldItemLayer.java
+++ b/src/main/java/tech/alexnijjar/golemoverhaul/client/renderers/entities/golems/layers/BarrelGolemHeldItemLayer.java
@@ -29,7 +29,7 @@ public class BarrelGolemHeldItemLayer extends GeoRenderLayer<BarrelGolem> {
         ItemStack stack = golem.getMainHandItem();
         if (stack.isEmpty()) return;
 
-        GeoBone itemBone = getGeoModel().getBone("entity").orElse(null);
+        GeoBone itemBone = getGeoModel().getBone("item").orElse(null);
         if (itemBone == null) return;
 
         float lerped = Mth.rotLerp(partialTick, golem.yBodyRotO, golem.yBodyRot);


### PR DESCRIPTION
Fixes #17

Before:
<img width="2560" height="1369" alt="bug" src="https://github.com/user-attachments/assets/77513405-f3a8-431a-b686-89361d47d98e" />

After:
<img width="2560" height="1369" alt="fix" src="https://github.com/user-attachments/assets/78e198a8-fd83-4a53-ae59-c3920f144515" />
