### PR TITLE
fix: netherite golem target switching

### DIFF
--- a/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/NetheriteGolem.java
+++ b/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/NetheriteGolem.java
@@ -456,7 +456,7 @@ public class NetheriteGolem extends BaseGolem implements IShearable, PlayerRidea
 
     @Override
     public boolean canAttack(LivingEntity target) {
-        return !this.isVehicle();
+        return !this.isVehicle() && super.canAttack(target);
     }
 
     @Override


### PR DESCRIPTION
The supercall was missing in `NetheriteGolem#canAttack`, leading to it never switching targets after killing one, as the `isAlive` check never ran on the previously killed target