### PR TITLE
fix: register sound keyframe handler for barrel golem's barter_controller

### DIFF
--- a/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/BarrelGolem.java
+++ b/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/BarrelGolem.java
@@ -409,7 +409,6 @@ public class BarrelGolem extends BaseGolem {
         this.level().broadcastEntityEvent(this, BARTER_EVENT_ID);
         this.changeStateTicks = this.getRandomChangeInterval();
         this.barteringTicks = BARTERING_TICKS;
-        playSound(ModSoundEvents.BARREL_GOLEM_BARTER.get());
     }
 
     @Override

--- a/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/BarrelGolem.java
+++ b/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/BarrelGolem.java
@@ -134,7 +134,8 @@ public class BarrelGolem extends BaseGolem {
             }
             state.resetCurrentAnimation();
             return PlayState.STOP;
-        }));
+        }).setSoundKeyframeHandler(event -> level().playLocalSound(blockPosition(),
+                ModSoundEvents.BARREL_GOLEM_BARTER.get(), getSoundSource(), 1, 1, false)));
     }
 
     @Override


### PR DESCRIPTION
Previously when bartering with a Barrel Golem, this warning was logged by GeckoLib:
```
Sound Keyframe found for BarrelGolem -> barter_controller, but no keyframe handler registered
```
The sound was played anyways, separately in `BarrelGolem#barter`. I've added a sound keyframe handler, now playing the sound from the keyframe in the animation and removed the original `playSound` call. This fix basically just gets rid of that warning.