### PR TITLE
fix: add default size for slime golem

### DIFF
--- a/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/SlimeGolem.java
+++ b/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/SlimeGolem.java
@@ -114,7 +114,13 @@ public class SlimeGolem extends BaseGolem {
     @Override
     public void readAdditionalSaveData(CompoundTag compound) {
         super.readAdditionalSaveData(compound);
-        this.setSize(Size.valueOf(compound.getString("Size").toUpperCase(Locale.ROOT)), false);
+
+        var sizeStr = compound.getString("Size").toUpperCase(Locale.ROOT);
+        if (sizeStr.isEmpty()) {
+            this.setSize(Size.LARGE, false);
+        } else {
+            this.setSize(Size.valueOf(sizeStr), false);
+        }
     }
 
     public Size getSize() {


### PR DESCRIPTION
I've made the Slime Golem's size default to `Size.LARGE` if there is no NBT compound available, which happened to me when running the command `/summon golemoverhaul:slime_golem`.

This would result in this error:
```
java.lang.IllegalArgumentException: No enum constant tech.alexnijjar.golemoverhaul.common.entities.golems.SlimeGolem.Size.
```

(which is the same as in #31, although I have no clue what caused it there)