### PR TITLE
tweak: golem target selection

### DIFF
--- a/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/base/BaseGolem.java
+++ b/src/main/java/tech/alexnijjar/golemoverhaul/common/entities/golems/base/BaseGolem.java
@@ -103,10 +103,10 @@ public abstract class BaseGolem extends AbstractGolem implements GeoEntity {
         this.targetSelector.removeGoal(this.attackTargetGoal);
 
         if (canMeleeAttack()) {
-            this.goalSelector.addGoal(1, this.meleeAttackGoal);
+            this.goalSelector.addGoal(2, this.meleeAttackGoal);
         }
         if (canTarget()) {
-            this.targetSelector.addGoal(2, this.hurtByTargetGoal);
+            this.targetSelector.addGoal(1, this.hurtByTargetGoal);
             this.targetSelector.addGoal(3, this.attackTargetGoal);
         }
     }


### PR DESCRIPTION
Now melee-attacking golems will also target entities they got hurt from first